### PR TITLE
Fix Twig depreciation for Symfony 2.8/3.0

### DIFF
--- a/Twig/FilesizeExtension.php
+++ b/Twig/FilesizeExtension.php
@@ -36,9 +36,7 @@ class FilesizeExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'readable_filesize' => new \Twig_Filter_Method(
-                $this, 'readableFilesize'
-            ),
+            new \Twig_SimpleFilter('readable_filesize', array($this, 'readableFilesize')),
         );
     }
 


### PR DESCRIPTION
```
Using an instance of "Twig_Filter_Method" for filter "readable_filesize" is deprecated.
Use Twig_SimpleFilter instead.
```
