### PR TITLE
Add support for input with suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,6 @@ $bundles = array(
 {{ file.size|readable_filesize }} {# 123.45 KB #}
 {{ file.size|readable_filesize(0) }} {# 123 KB #}
 {{ file.size|readable_filesize(0, '') }} {# 123KB #}
+{# Also support conversion between units #}
+{{ '102400 KB'|readable_filesize }} {# 100 MB #}
 ```

--- a/Tests/Twig/FilesizeExtensionTest.php
+++ b/Tests/Twig/FilesizeExtensionTest.php
@@ -55,4 +55,19 @@ class FilesizeExtensionTest extends TestCase
             '2KB', $this->fse->readableFilesize(2 * KB, 0, '')
         );
     }
+    public function testSuffix()
+    {
+        $this->assertEquals('12.35 KB', $this->fse->readableFilesize('12.3456 KB'));
+        $this->assertEquals('12.35 MB', $this->fse->readableFilesize('12.3456 MB'));
+        $this->assertEquals('12.35 GB', $this->fse->readableFilesize('12.3456 GB'));
+        $this->assertEquals('12.35 TB', $this->fse->readableFilesize('12.3456 TB'));
+        $this->assertEquals('12.35 PB', $this->fse->readableFilesize('12.3456 PB'));
+        $this->assertEquals('12.06 GB', $this->fse->readableFilesize(12.06*KB . ' MB'));
+        $this->assertEquals('12.34 TB', $this->fse->readableFilesize(12.34/KB . 'PB'));
+    }
+
+    public function testVeryBigNumber()
+    {
+        $this->assertEquals('1.18 PB', $this->fse->readableFilesize('1324567890123456'));
+    }
 }

--- a/Twig/FilesizeExtension.php
+++ b/Twig/FilesizeExtension.php
@@ -8,22 +8,28 @@ use Twig\TwigFilter;
 class FilesizeExtension extends AbstractExtension
 {
     /**
-     * @param integer $size
+     * @param mixed $size
      * @param integer $precision
      * @param string  $space
      * @return string
      */
     public function readableFilesize($size, $precision = 2, $space = ' ')
     {
+        $mod = 1024;
+
+        if (preg_match('/(^.*\d)\s*([kmgtp])(i?b)/i', $size, $match)) {
+            $exponent = strpos('KMGTP', strtoupper($match[2])) + 1;
+            $size = $match[1] * $mod**$exponent;
+        }
+
         if( $size <= 0 ) {
             return '0' . $space . 'KB';
         }
 
-        if( $size === 1 ) {
+        if( (int)$size === 1 ) {
             return '1' . $space . 'byte';
         }
 
-        $mod = 1024;
         $units = array('bytes', 'KB', 'MB', 'GB', 'TB', 'PB');
 
         for( $i = 0; $size > $mod && $i < count($units) - 1; ++$i ) {


### PR DESCRIPTION
Instead of raw number of bytes, adding support for number with suffix e.g. `10240 MB` will be formatted as `10 GB`.